### PR TITLE
Prevent Clang errors and warnings when building CMSIS.

### DIFF
--- a/CMSIS/Include/cmsis_gcc.h
+++ b/CMSIS/Include/cmsis_gcc.h
@@ -335,10 +335,14 @@ __attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_FPSCR(void)
 __attribute__( ( always_inline ) ) __STATIC_INLINE void __set_FPSCR(uint32_t fpscr)
 {
 #if (__FPU_PRESENT == 1U) && (__FPU_USED == 1U)
+#ifdef __clang__
+  __builtin_arm_set_fpscr(fpscr);
+#else
   /* Empty asm statement works as a scheduling barrier */
   __ASM volatile ("");
   __ASM volatile ("VMSR fpscr, %0" : : "r" (fpscr) : "vfpcc");
   __ASM volatile ("");
+#endif
 #endif
 }
 

--- a/CMSIS/RTOS/RTX/INC/RTX_CM_lib.h
+++ b/CMSIS/RTOS/RTX/INC/RTX_CM_lib.h
@@ -36,7 +36,9 @@
 #pragma O3
 #define __USED __attribute__((used))
 #elif defined (__GNUC__)
+#if !defined(__clang__)
 #pragma GCC optimize ("O3")
+#endif
 #define __USED __attribute__((used))
 #elif defined (__ICCARM__)
 #define __USED __root


### PR DESCRIPTION
Prevent Clang errors and warnings when building CMSIS.

Signed-off-by: Olivier Martin olivier@labapart.com
