### PR TITLE
RTOS/RTX: Prevent to release more semaphore than the number of resource

### DIFF
--- a/CMSIS/RTOS/RTX/INC/cmsis_os.h
+++ b/CMSIS/RTOS/RTX/INC/cmsis_os.h
@@ -385,7 +385,7 @@ int32_t osSignalSet (osThreadId thread_id, int32_t signals);
 /// \return previous signal flags of the specified thread or 0x80000000 in case of incorrect parameters or call from ISR.
 int32_t osSignalClear (osThreadId thread_id, int32_t signals);
 
-/// Wait for one or more Signal Flags to become signaled for the current \b RUNNING thread.
+/// Wait and clear one or more Signal Flags to become signaled for the current \b RUNNING thread.
 /// \param[in]     signals       wait until all specified signal flags set or 0 for any single signal flag.
 /// \param[in]     millisec      \ref CMSIS_RTOS_TimeOutValue or 0 in case of no time-out.
 /// \return event flag information or error code.
@@ -443,7 +443,7 @@ osStatus osMutexDelete (osMutexId mutex_id);
 extern const osSemaphoreDef_t os_semaphore_def_##name
 #else                            // define the object
 #define osSemaphoreDef(name)  \
-uint32_t os_semaphore_cb_##name[2] = { 0 }; \
+uint32_t os_semaphore_cb_##name[3] = { 0 }; \
 const osSemaphoreDef_t os_semaphore_def_##name = { (os_semaphore_cb_##name) }
 #endif
 

--- a/CMSIS/RTOS/RTX/SRC/rt_CMSIS.c
+++ b/CMSIS/RTOS/RTX/SRC/rt_CMSIS.c
@@ -1590,9 +1590,12 @@ osStatus svcSemaphoreRelease (osSemaphoreId semaphore_id) {
     return osErrorResource;
   }
   
-  rt_sem_send(sem);                             // Release Semaphore
-
-  return osOK;
+  // Release Semaphore
+  if (rt_sem_send(sem) == OS_R_OK) {
+    return osOK;
+  } else {
+    return osErrorResource;
+  }
 }
 
 /// Delete a Semaphore that was created by osSemaphoreCreate

--- a/CMSIS/RTOS/RTX/SRC/rt_Semaphore.c
+++ b/CMSIS/RTOS/RTX/SRC/rt_Semaphore.c
@@ -52,9 +52,10 @@ void rt_sem_init (OS_ID semaphore, U16 token_count) {
   /* Initialize a semaphore */
   P_SCB p_SCB = semaphore;
 
-  p_SCB->cb_type = SCB;
-  p_SCB->p_lnk  = NULL;
-  p_SCB->tokens = token_count;
+  p_SCB->cb_type    = SCB;
+  p_SCB->p_lnk      = NULL;
+  p_SCB->tokens     = token_count;
+  p_SCB->max_tokens = token_count;
 }
 
 
@@ -95,6 +96,10 @@ OS_RESULT rt_sem_send (OS_ID semaphore) {
   /* Return a token to semaphore */
   P_SCB p_SCB = semaphore;
   P_TCB p_TCB;
+
+  if (p_SCB->tokens == p_SCB->max_tokens) {
+    return OS_R_NOK;
+  }
 
   if (p_SCB->p_lnk != NULL) {
     /* A task is waiting for token */

--- a/CMSIS/RTOS/RTX/SRC/rt_TypeDef.h
+++ b/CMSIS/RTOS/RTX/SRC/rt_TypeDef.h
@@ -130,6 +130,7 @@ typedef struct OS_SCB {
   U8     mask;                    /* Semaphore token mask                    */
   U16    tokens;                  /* Semaphore tokens                        */
   struct OS_TCB *p_lnk;           /* Chain of tasks waiting for tokens       */
+  U16    max_tokens;              /* Maximum number of Semaphore tokens      */
 } *P_SCB;
 
 typedef struct OS_MUCB {


### PR DESCRIPTION
Prior to this change, calling osSemaphoreRelease() too many time
will allocate additional resource to the initial number of resources.
