### PR TITLE
Semaphore tokens can be acquired in an interrupt context.

### DIFF
--- a/CMSIS/RTOS/RTX/SRC/rt_Semaphore.c
+++ b/CMSIS/RTOS/RTX/SRC/rt_Semaphore.c
@@ -153,6 +153,26 @@ void isr_sem_send (OS_ID semaphore) {
 }
 
 
+/*--------------------------- isr_sem_wait ----------------------------------*/
+
+OS_RESULT isr_sem_wait (OS_ID semaphore) {
+  /* Same function as "os_sem_wait", but to be called by ISRs. The function */
+  /* returns immediately, if the semaphore has no token since it would      */
+  /* block the rtx os otherwise.                                            */
+  P_SCB p_SCB = semaphore;
+
+  if (p_SCB->tokens) {
+    /* A token is available in the semaphore. */
+    rt_dec (&p_SCB->tokens);
+    return (OS_R_OK);
+  }
+  else {
+    /* The semaphore is empty. */
+    return (OS_R_TMO);
+  }
+}
+
+
 /*--------------------------- rt_sem_psh ------------------------------------*/
 
 void rt_sem_psh (P_SCB p_CB) {
@@ -180,3 +200,4 @@ void rt_sem_psh (P_SCB p_CB) {
 /*----------------------------------------------------------------------------
  * end of file
  *---------------------------------------------------------------------------*/
+

--- a/CMSIS/RTOS/RTX/SRC/rt_Semaphore.h
+++ b/CMSIS/RTOS/RTX/SRC/rt_Semaphore.h
@@ -38,6 +38,7 @@ extern OS_RESULT rt_sem_delete(OS_ID semaphore);
 extern OS_RESULT rt_sem_send  (OS_ID semaphore);
 extern OS_RESULT rt_sem_wait  (OS_ID semaphore, U16 timeout);
 extern void      isr_sem_send (OS_ID semaphore);
+extern OS_RESULT isr_sem_wait (OS_ID semaphore);
 extern void      rt_sem_psh (P_SCB p_CB);
 
 /*----------------------------------------------------------------------------


### PR DESCRIPTION
The semaphore and message queue functions share some nice symmetry:

```
osMessagePut() <--> osSemaphoreRelease()
osMessageGet() <--> osSemaphoreWait()
```

Putting a message into a queue is similar to giving a token back to a semaphore. Fetching
a message from a queue is like acquiring a token from a semaphore. The only asymmetry
is that `osSemaphoreWait()` cannot be used in an interrupt context, whereas all other three
functions can.

This patch makes `osSemaphoreWait()` usable in an interrupt context given that the timeout
is set to 0ms. This is the same behavior as for `osMessagePut()` and `osMessageGet()`.

This simple change allows to keep track of resources and to acquire them in an ISR.
For example, by coupling a memory pool with a semaphore, on can create a blocking memory
pool which operates in both the thread and the interrupt context. For example:

```
typedef struct
{
    osSemaphoreId sem;
    osPoolId memPool;
} BlockingPool;

// Allocate a pool element. Can be called from an ISR if millisecs == 0.
void* BlockingPool_allocate(BlockingPool* pool, uint32_t millisecs)
{
    if (osSemaphoreWait(pool->sem, millisecs) > 0)
        return osPoolAlloc(pool->memPool);  // This returns non-NULL for sure.
    else
        return NULL;
}

// Free a pool element. Can be called from an ISR.
void BlockingPool_free(BlockingPool* pool, void* mem)
{
    osPoolFree(pool->memPool, mem);
    osSemaphoreRelease(pool->sem);
}
```
