### PR TITLE
Add a non-recursive mutex.

### DIFF
--- a/CMSIS/RTOS/RTX/INC/cmsis_os.h
+++ b/CMSIS/RTOS/RTX/INC/cmsis_os.h
@@ -410,10 +410,33 @@ const osMutexDef_t os_mutex_def_##name = { (os_mutex_cb_##name) }
 #define osMutex(name)  \
 &os_mutex_def_##name
 
-/// Create and Initialize a Mutex object.
+/// Create and Initialize a Recursive Mutex object.
 /// \param[in]     mutex_def     mutex definition referenced with \ref osMutex.
 /// \return mutex ID for reference by other functions or NULL in case of error.
 osMutexId osMutexCreate (const osMutexDef_t *mutex_def);
+
+/// Create and Initialize a Plain Mutex object.
+/// \param[in]     mutex_def     mutex definition referenced with \ref osMutex.
+/// \return mutex ID for reference by other functions or NULL in case of error.
+osMutexId osPlainMutexCreate (const osMutexDef_t *mutex_def);
+
+#if 0
+// Alternatively, we could have only one osMutexCreate() function, which takes
+// the type of the mutex as parameter. This is probably the more elegant
+// solution but breaks the existing API.
+
+/// An enumeration of Mutex types.
+typedef enum  {
+  osMutexPlain            =     0,       ///< plain mutex
+  osMutexRecursive        =     1        ///< recursive mutex
+} os_mutex_type;
+
+/// Create and Initialize a Mutex object.
+/// \param[in]     mutex_def     mutex definition referenced with \ref osMutex.
+/// \param[in]     type          osMutexPlain for a non-recursive mutex or osMutexRecursive for a recursive mutex.
+/// \return mutex ID for reference by other functions or NULL in case of error.
+osMutexId osMutexCreate (const osMutexDef_t *mutex_def, os_mutex_type type);
+#endif
 
 /// Wait until a Mutex becomes available.
 /// \param[in]     mutex_id      mutex ID obtained by \ref osMutexCreate.

--- a/CMSIS/RTOS/RTX/SRC/rt_Mutex.c
+++ b/CMSIS/RTOS/RTX/SRC/rt_Mutex.c
@@ -47,15 +47,16 @@
 
 /*--------------------------- rt_mut_init -----------------------------------*/
 
-void rt_mut_init (OS_ID mutex) {
+void rt_mut_init (OS_ID mutex, U8 recursive) {
   /* Initialize a mutex object */
   P_MUCB p_MCB = mutex;
 
-  p_MCB->cb_type = MUCB;
-  p_MCB->level   = 0U;
-  p_MCB->p_lnk   = NULL;
-  p_MCB->owner   = NULL;
-  p_MCB->p_mlnk  = NULL;
+  p_MCB->cb_type   = MUCB;
+  p_MCB->recursive = recursive;
+  p_MCB->level     = 0U;
+  p_MCB->p_lnk     = NULL;
+  p_MCB->owner     = NULL;
+  p_MCB->p_mlnk    = NULL;
 }
 
 
@@ -227,6 +228,10 @@ OS_RESULT rt_mut_wait (OS_ID mutex, U16 timeout) {
   }
   if (p_MCB->owner == os_tsk.run) {
     /* OK, running task is the owner of this mutex. */
+    if (!p_MCB->recursive) {
+      /* The mutex is not recursive but the task tries to lock it again. */
+      return (OS_R_NOK);
+    }
 inc:p_MCB->level++;
     return (OS_R_OK);
   }

--- a/CMSIS/RTOS/RTX/SRC/rt_Mutex.h
+++ b/CMSIS/RTOS/RTX/SRC/rt_Mutex.h
@@ -33,7 +33,7 @@
  *---------------------------------------------------------------------------*/
 
 /* Functions */
-extern void      rt_mut_init    (OS_ID mutex);
+extern void      rt_mut_init    (OS_ID mutex, U8 recursive);
 extern OS_RESULT rt_mut_delete  (OS_ID mutex);
 extern OS_RESULT rt_mut_release (OS_ID mutex);
 extern OS_RESULT rt_mut_wait    (OS_ID mutex, U16 timeout);

--- a/CMSIS/RTOS/RTX/SRC/rt_TypeDef.h
+++ b/CMSIS/RTOS/RTX/SRC/rt_TypeDef.h
@@ -134,6 +134,7 @@ typedef struct OS_SCB {
 
 typedef struct OS_MUCB {
   U8     cb_type;                 /* Control Block Type                      */
+  U8     recursive;               /* If set, the mutex is recursive          */
   U16    level;                   /* Call nesting level                      */
   struct OS_TCB *p_lnk;           /* Chain of tasks waiting for mutex        */
   struct OS_TCB *owner;           /* Mutex owner task                        */


### PR DESCRIPTION
As recursive mutexes are frequently considered to be less secure compared to plain mutexes (see [here](https://cppwisdom.quora.com/Recursive-mutexes-considered-harmful) or [here](http://www.zaval.org/resources/library/butenhof1.html), for example), let's add a non-recursive variant to the RTOS.

The change is quite straightforward: An unused padding byte of the mutex structure is used for storing a flag which discriminates plain and recursive mutexes. The flag is checked in `rt_mut_wait()`. If a task tries to re-lock a plain mutex which it has already acquired, the nesting level is not changed and an error is returned.

In order not to break the existing API, a function `osPlainMutexCreate()` has been added to
create a plain (non-recursive) mutex. The existing function `osMutexCreate()` is used to initialize a recursive mutex as usual.

Alternatively, one could change the signature of

```
osMutexId osMutexCreate (const osMutexDef_t *mutex_def);
```

to

```
osMutexId osMutexCreate (const osMutexDef_t *mutex_def, os_mutex_type type);
```

and pass the `type` of the mutex as parameter. The latter is more elegant in my opinion but it breaks the existing API, of course.
